### PR TITLE
SCAL 690

### DIFF
--- a/app/models/supervisor_run.rb
+++ b/app/models/supervisor_run.rb
@@ -21,7 +21,7 @@ class SupervisorRun < MongoActiveRecord
   # This method is needed for proper work of MongoActiveRecord,
   # its specifies collections name in database
   def self.collection_name
-    'supervisors'
+    'supervisor_runs'
   end
 
   ##
@@ -97,8 +97,15 @@ class SupervisorRun < MongoActiveRecord
 
   ##
   # Returns last 100 lines of script log
-  def read_log()
-    IO.readlines(log_path)[-100..-1].join
+  def read_log
+    begin
+      log = IO.readlines(log_path)
+      log = log[-100..-1] if log.size > 100
+      log.join
+    rescue => e
+      Rails.logger.debug "Unable to load log file #{e.to_s}"
+      ''
+    end
   end
 
   ##

--- a/app/models/supervisor_run.rb
+++ b/app/models/supervisor_run.rb
@@ -103,8 +103,8 @@ class SupervisorRun < MongoActiveRecord
       log = log[-100..-1] if log.size > 100
       log.join
     rescue => e
-      Rails.logger.debug "Unable to load log file #{e.to_s}"
-      ''
+      Rails.logger.debug "Unable to load log file: #{log_path}\n#{e.to_s}"
+      "Unable to load log file: #{log_path}"
     end
   end
 

--- a/app/models/supervisor_run_watcher.rb
+++ b/app/models/supervisor_run_watcher.rb
@@ -51,7 +51,7 @@ class SupervisorRunWatcher
             s.monitoring_loop
             s.save
           end
-        rescue RuntimeError => e
+        rescue => e
            Rails.logger.info "Error while execution script monitoring loop #{e.to_s}"
            @@is_running = false
            return

--- a/test/models/supervisor_run_test.rb
+++ b/test/models/supervisor_run_test.rb
@@ -102,13 +102,39 @@ class SupervisorRunTest < ActiveSupport::TestCase
 
   FILE_PATH = '/tmp/test.txt'
 
-  test "proper behavior od read_log method" do
-    @supervisor_script.stubs(:log_path).returns(FILE_PATH)
+  test "proper behavior od read_log method when lines number is greater than 100" do
+    @supervisor_script.expects(:log_path).returns(FILE_PATH)
 
     File.open(FILE_PATH, 'w+') do |file|
-      (1..200).each {|x| file.write("#{x}\n")}
+      (1..101).each {|x| file.write("#{x}\n")}
     end
-    assert_equal @supervisor_script.read_log, "#{(101..200).to_a.join("\n")}\n"
+    assert_equal @supervisor_script.read_log, "#{(2..101).to_a.join("\n")}\n"
     File.delete(FILE_PATH)
+  end
+
+  test "proper behavior od read_log method when lines number is lower than 100" do
+    @supervisor_script.expects(:log_path).returns(FILE_PATH)
+
+    File.open(FILE_PATH, 'w+') do |file|
+      (1..99).each {|x| file.write("#{x}\n")}
+    end
+    assert_equal @supervisor_script.read_log, "#{(1..99).to_a.join("\n")}\n"
+    File.delete(FILE_PATH)
+  end
+
+  test "proper behavior od read_log method when lines number is equal 100" do
+    @supervisor_script.expects(:log_path).returns(FILE_PATH)
+
+    File.open(FILE_PATH, 'w+') do |file|
+      (1..100).each {|x| file.write("#{x}\n")}
+    end
+    assert_equal @supervisor_script.read_log, "#{(1..100).to_a.join("\n")}\n"
+    File.delete(FILE_PATH)
+  end
+
+  test "proper behavior od read_log method on file reading error" do
+    @supervisor_script.expects(:log_path).returns(FILE_PATH)
+    IO.expects(:readlines).with(FILE_PATH).throws(StandardError)
+    assert_equal @supervisor_script.read_log, ''
   end
 end

--- a/test/models/supervisor_run_test.rb
+++ b/test/models/supervisor_run_test.rb
@@ -133,8 +133,8 @@ class SupervisorRunTest < ActiveSupport::TestCase
   end
 
   test "proper behavior od read_log method on file reading error" do
-    @supervisor_script.expects(:log_path).returns(FILE_PATH)
+    @supervisor_script.expects(:log_path).times(3).returns(FILE_PATH)
     IO.expects(:readlines).with(FILE_PATH).throws(StandardError)
-    assert_equal @supervisor_script.read_log, ''
+    assert_equal @supervisor_script.read_log, "Unable to load log file: #{FILE_PATH}"
   end
 end


### PR DESCRIPTION
Poprawka błędu wspomnianego na spotkaniu, sposób w jaki to wycinałem nie działał jeśli log miał mniej niż 100 linii, poprawiłem i dodałem testy sprawdzające taką sytuację. Dodatkowo poprawiłem łapanie wyjątków w watcherze bo taka sytuacja powinna zostać zalogowana oraz nazwę kolekcji co zostało zapomniane przy zmianie nazw.
