### PR TITLE
Scal 758

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,5 @@ gem 'haml'
 # Use debugger
 # gem 'debugger', group: [:development, :test]
 
+gem 'thin'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,9 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1)
+    daemons (1.1.9)
     erubis (2.7.0)
+    eventmachine (1.0.3)
     execjs (2.4.0)
     haml (4.0.5)
       tilt
@@ -101,6 +103,10 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    thin (1.6.2)
+      daemons (>= 1.0.9)
+      eventmachine (>= 1.0.0)
+      rack (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -128,4 +134,5 @@ DEPENDENCIES
   rest-client (~> 1.6.7)
   sdoc (~> 0.4.0)
   spring
+  thin
   turbolinks

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,18 @@ Rails.application.load_tasks
 
 LOCAL_MONGOS_PATH = 'bin/mongos'
 
+namespace :service do
+  desc 'Start the service'
+  task :start => :environment do
+    %x[thin start -d -C config/thin.yml]
+  end
+
+  desc 'Stop the service'
+  task :stop => :environment do
+    %x[thin stop -C config/thin.yml]
+  end
+end
+
 namespace :db_router do
   desc 'Start MongoDB router'
   task :start, [:debug] => [:environment, :setup] do |t, args|

--- a/app/controllers/supervisor_runs_controller.rb
+++ b/app/controllers/supervisor_runs_controller.rb
@@ -100,6 +100,7 @@ class SupervisorRunsController < ApplicationController
     response = {}
     begin
       supervisor_run = SupervisorRun.new({})
+      # TODO: params[:config] can be not only JSON but also Hash (parsed by Rails)
       pid = supervisor_run.start (params[:supervisor_id] || params[:id]), JSON.parse(params[:config])
       supervisor_run.save
       Rails.logger.debug supervisor_run

--- a/supervisors/executables/morris/.gitignore
+++ b/supervisors/executables/morris/.gitignore
@@ -1,0 +1,6 @@
+SensitivityAnalysis.dll
+Newtonsoft.json.dll
+RestSharp.dll
+Scalarm.dll
+sensitivity_analysis.exe
+sensitivity_analysis.exe.mdb

--- a/supervisors/executables/morris/README
+++ b/supervisors/executables/morris/README
@@ -1,0 +1,6 @@
+Files required in this directory:
+- Newtonsoft.json.dll - Newtonsoft Json library for .Net 4.0
+- RestSharp.dll - RestSharp library for .Net 4.0
+- Scalarm.dll - Scalarm Client library
+- sensitivity_analysis.exe - a sensitivity analysis supervisor executable: https://github.com/Scalarm/sensitivity_analysis_supervisor
+- SensitivityAnalysis.dll - Sensitivity Analysis closed-source library by Daniel Bachniak

--- a/supervisors/executors/morris_executor.rb
+++ b/supervisors/executors/morris_executor.rb
@@ -1,0 +1,38 @@
+require 'supervisor_executors/abstract_supervisor_executor'
+
+##
+# Sensitivity analysis with Morris Design
+# Using Sensitivity Analysis library by Daniel Bachniak, 2015
+# Copyright (c) Daniel Bachniak 2015
+#
+# ==== Supervisor specific parameters:
+# morris_samples_count::
+# morris_levels_count::
+#
+# ==== Dependencies to run supervisor:
+# [mono runtime]
+# [sensitivity analysis library] should be in executables/morris/SensitivityAnalysis.dll
+class MorrisExecutor < AbstractSupervisorExecutor
+
+  BIN_DIR = 'supervisors/executables/morris/'
+  BIN_NAME = 'sensitivity_analysis.exe'
+  CONFIG_FILE_PREFIX = '/tmp/morris_config_'
+
+  # overrides parent method
+  def self.start(config)
+    script_config = "#{CONFIG_FILE_PREFIX}#{config['experiment_id']}"
+    File.open(script_config, 'w+') { |file| file.write(config.to_json) }
+    script_log = self.log_path(config['experiment_id']).to_s
+    Dir.chdir(BIN_DIR) do
+      pid = Process.spawn("mono #{BIN_NAME} #{script_config}", out: script_log, err: script_log)
+      Process.detach(pid)
+      pid
+    end
+  end
+
+  # overrides parent method
+  def self.cleanup(experiment_id)
+    File.delete self.log_path(experiment_id) if File.exists? self.log_path(experiment_id)
+    File.delete "#{CONFIG_FILE_PREFIX}#{experiment_id}" if File.exists? "#{CONFIG_FILE_PREFIX}#{experiment_id}"
+  end
+end

--- a/supervisors/manifest/morris.yml
+++ b/supervisors/manifest/morris.yml
@@ -1,0 +1,1 @@
+name: 'Sensitivity Analysis with Morris Design'


### PR DESCRIPTION
Integracja analizy wrażliwości Morrisa

Do zrobienia:
- naprawa działania wszystkich eksperymentów (obecnie działała tylko Celsa)
- ustawienie uprawnień i pokazywanie tej metody tylko jeśli: są pliki binarne (nie ma na repozytorium, bo biblioteka jest binarna i chroniona prawem autorskim), wyświetlanie tylko wybranym użytkownikom (w przyszłości - użytkownikom, którzy mają aktywowane ManuOpti w LDAP-ie i użytkownikom Virtrolla)

Obecnie dorzucam do development.
