### PR TITLE
SCAL-1003: Changing float fields from number to text

### DIFF
--- a/supervisors/simulated_annealing/anneal.py
+++ b/supervisors/simulated_annealing/anneal.py
@@ -43,7 +43,8 @@ def anneal(initial_temperature,
            spread):
     if points_limit == 0:
         points_limit = float('inf')
-    temperature = float(initial_temperature)
+    initial_temperature = float(initial_temperature)
+    temperature = initial_temperature
     cooling_rate = float(cooling_rate)
 
     best_point = start_point

--- a/supervisors/simulated_annealing/start_panel.html.haml
+++ b/supervisors/simulated_annealing/start_panel.html.haml
@@ -10,13 +10,13 @@
         .small-5.columns
           = label_tag :initial_temperature, 'Initial temperature:', class: 'right inline'
         .small-4.columns.end
-          = number_field_tag :initial_temperature, 1000, min: 1, required: true, class: 'text-right'
+          = text_field_tag :initial_temperature, 1000, required: true, class: 'text-right'
 
       .row
         .small-5.columns
           = label_tag :cooling_rate, 'Cooling rate [0-1]:', class: 'right inline'
         .small-4.columns.end
-          = number_field_tag :cooling_rate, 0.001, min: 0, required: true, class: 'text-right'
+          = text_field_tag :cooling_rate, 0.001, required: true, class: 'text-right'
 
       .row
         .small-5.columns


### PR DESCRIPTION
Fields for floats were created as number_field_tag, where decimal separator is comma. Changing to text_field_tag to allow use of dot instead.
