### PR TITLE
SCAL-1029: move logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ default: &DEFAULT
   db_secret_key: "QjqjFK}7|Xw8DDMUP-O$yp"
   supervisor_script_watcher:
     sleep_duration_in_seconds: 60
+  # Path where logs are moved after supervisor run execution finish.
+  # log_archive_path: /some/path
 
 development:
   <<: *DEFAULT

--- a/app/models/supervisor_executors/abstract_supervisor_executor.rb
+++ b/app/models/supervisor_executors/abstract_supervisor_executor.rb
@@ -35,6 +35,7 @@ class AbstractSupervisorExecutor
   # Template for invoking cleanup method
   def self._cleanup(experiment_id)
     validate_experiment_id!(experiment_id)
+    self.delete_logs(experiment_id)
     cleanup(experiment_id)
   end
 
@@ -55,7 +56,13 @@ class AbstractSupervisorExecutor
   ##
   # Default log path. Override if needed.
   def self.log_path(experiment_id)
-    Rails.root.join('log', "supervisor_script_#{experiment_id}.log")
+    Rails.root.join('log', log_file_name(experiment_id))
+  end
+
+  ##
+  # Returns log file default name
+  def self.log_file_name(experiment_id)
+    "supervisor_script_#{experiment_id}.log"
   end
 
   ##
@@ -65,5 +72,14 @@ class AbstractSupervisorExecutor
   def self.config_file_path(experiment_id)
     config_suffix = SecureRandom.hex(8)
     [CONFIG_FILE_PREFIX, experiment_id, config_suffix].join('_')
+  end
+
+  private
+
+  ##
+  # Removes supervisor_run logs
+  def self.delete_logs(experiment_id)
+    log_path = self.log_path experiment_id
+    File.delete(log_path) if File.exists?(log_path)
   end
 end

--- a/supervisors/morris/morris_executor.rb
+++ b/supervisors/morris/morris_executor.rb
@@ -32,7 +32,7 @@ class MorrisExecutor < AbstractSupervisorExecutor
 
   # overrides parent method
   def self.cleanup(experiment_id)
-    files_to_delete = [self.log_path(experiment_id), self.config_file_path(experiment_id)]
+    files_to_delete = [self.config_file_path(experiment_id)]
     files_to_delete.each do |path|
       File.delete(path) if File.exists?(path)
     end

--- a/supervisors/simulated_annealing/simulated_annealing_executor.rb
+++ b/supervisors/simulated_annealing/simulated_annealing_executor.rb
@@ -43,7 +43,7 @@ class SimulatedAnnealingExecutor < AbstractSupervisorExecutor
 
   # overrides parent method
   def self.cleanup(experiment_id)
-    files_to_delete = [self.log_path(experiment_id), self.config_file_path(experiment_id)]
+    files_to_delete = [self.config_file_path(experiment_id)]
     files_to_delete.each do |path|
       File.delete(path) if File.exists?(path)
     end


### PR DESCRIPTION
Po zaakceptowaniu zmerguje ręcznie.
- usuwanie logów przeniesione do abstract watcher
- przenoszenie logów do archiwum
