### PR TITLE
SCAL-1082: Fixing error when config entry is missing.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -176,8 +176,10 @@ def copy_example_config_if_not_exists(base_name, prefix='example')
 end
 
 def validate_secrets
-  archive_log_path = Rails.application.secrets.log_archive_path
-  unless Dir.exist? archive_log_path
-    raise "ERROR: Invalid path in config file (config/secrets.yml) entry log_archive_path: #{archive_log_path}"
+  if Rails.application.secrets.include? :log_archive_path
+    archive_log_path = Rails.application.secrets.log_archive_path
+    unless Dir.exist? archive_log_path
+      raise "ERROR: Invalid path in config file (config/secrets.yml) entry log_archive_path: #{archive_log_path}"
+    end
   end
 end


### PR DESCRIPTION
https://jira.plgrid.pl/jira/browse/SCAL-1082

Kiedy nie było wpisu w secrets nie można było uruchamiać supervisora, zrobiłem poprawkę.
