### PR TITLE
SCAL-1084 Exceptions handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ default: &DEFAULT
     ## NOTICE: this key should be set ONLY ONCE BEFORE first run - if you change or lost it, you will be UNABLE to read encrypted data!
     db_secret_key: "QjqjFK}7|Xw8DDMUP-O$yp"
 
-  ## Set an interval of script watching (checking if scripts are alive)
   supervisor_script_watcher:
+    ## Set an interval of script watching (checking if scripts are alive)
     sleep_duration_in_seconds: 60
+    ## Set retrying limit of monitoring loop after error
+    errors_limit = 3
     
   ## Path where logs are moved after supervisor run execution finish.
   # log_archive_path: /some/path

--- a/app/controllers/supervisor_runs_controller.rb
+++ b/app/controllers/supervisor_runs_controller.rb
@@ -139,8 +139,7 @@ class SupervisorRunsController < ApplicationController
     begin
       supervisor_run = SupervisorRun.new
       # TODO: params[:config] can be not only JSON but also Hash (parsed by Rails)
-      pid = supervisor_run.start (params[:supervisor_id] || params[:id]), experiment_id.to_s, current_user.id, config
-      supervisor_run.save
+      pid = supervisor_run.start!((params[:supervisor_id] || params[:id]), experiment_id.to_s, current_user.id, config)
       Rails.logger.debug supervisor_run
       response = {status: 'ok', pid: pid, supervisor_run_id: supervisor_run.id.to_s}
 
@@ -158,8 +157,7 @@ class SupervisorRunsController < ApplicationController
   end
 
   def stop
-    @supervisor_run.stop
-    @supervisor_run.save
+    @supervisor_run.stop!
     render json: {status: 'ok'}
   end
 

--- a/app/controllers/supervisor_runs_controller.rb
+++ b/app/controllers/supervisor_runs_controller.rb
@@ -137,7 +137,7 @@ class SupervisorRunsController < ApplicationController
     #TODO validate and check errors
     response = {}
     begin
-      supervisor_run = SupervisorRun.new({})
+      supervisor_run = SupervisorRun.new
       # TODO: params[:config] can be not only JSON but also Hash (parsed by Rails)
       pid = supervisor_run.start (params[:supervisor_id] || params[:id]), experiment_id.to_s, current_user.id, config
       supervisor_run.save

--- a/app/models/supervisor_run.rb
+++ b/app/models/supervisor_run.rb
@@ -175,6 +175,20 @@ class SupervisorRun < Scalarm::Database::MongoActiveRecord
     super
   end
 
+  ##
+  # Creates persistent method version with exclamation mark
+  def self.declare_persistent_method(name)
+    define_method("#{name}!".to_sym) do |*args|
+      result = send(name, *args)
+      save
+      result
+    end
+  end
+  declare_persistent_method :start
+  declare_persistent_method :monitoring_loop
+  declare_persistent_method :set_error
+  declare_persistent_method :stop
+
   private
 
   ##

--- a/app/models/supervisor_run.rb
+++ b/app/models/supervisor_run.rb
@@ -23,7 +23,7 @@ Dir[Rails.root.join('supervisors', '*', '*_executor.rb').to_s].each {|file| requ
 #   * password
 # * is_error - set to true when error occurred during supervisor execution (set by #start, modified by #set_error)
 # * error_reason - reason of error (set by #set_error)
-# Be careful, variables and its usages list may be incomplete.
+# Be careful, variables and their usages list may be incomplete.
 # TODO: I think we should add simulation_manager_temp_password_id to avoid redundancy
 class SupervisorRun < Scalarm::Database::MongoActiveRecord
   use_collection 'supervisor_runs'
@@ -177,17 +177,16 @@ class SupervisorRun < Scalarm::Database::MongoActiveRecord
 
   ##
   # Creates persistent method version with exclamation mark
-  def self.declare_persistent_method(name)
-    define_method("#{name}!".to_sym) do |*args|
-      result = send(name, *args)
-      save
-      result
+  def self.declare_persistent_method(*names)
+    names.each do |name|
+      define_method("#{name}!".to_sym) do |*args|
+        result = send(name, *args)
+        save
+        result
+      end
     end
   end
-  declare_persistent_method :start
-  declare_persistent_method :monitoring_loop
-  declare_persistent_method :set_error
-  declare_persistent_method :stop
+  declare_persistent_method :start, :monitoring_loop, :set_error, :stop
 
   private
 

--- a/app/models/supervisor_run_watcher.rb
+++ b/app/models/supervisor_run_watcher.rb
@@ -5,16 +5,20 @@ require 'thread'
 # monitoring_loop of SupervisorScript class which is_running flag is true, in given
 # moment only one monitoring thread is running.
 class SupervisorRunWatcher
-  @@is_running = false
-  @@mutex = Mutex.new
-  @@sleep_duration_in_seconds = 60
+  @is_running = false
+  @mutex = Mutex.new
+  @sleep_duration_in_seconds = 60
+  @errors_limit = 3
 
   ##
   # Allows to set custom sleep time
   def self.init
     if Rails.application.secrets.include? :supervisor_script_watcher
-      if Rails.application.secrets.supervisor_script_watcher.has_key?("sleep_duration_in_seconds")
-        @@sleep_duration_in_seconds = Rails.application.secrets.supervisor_script_watcher["sleep_duration_in_seconds"]
+      if Rails.application.secrets.supervisor_script_watcher.has_key?('sleep_duration_in_seconds')
+        @sleep_duration_in_seconds = Rails.application.secrets.supervisor_script_watcher['sleep_duration_in_seconds']
+      end
+      if Rails.application.secrets.supervisor_script_watcher.has_key?('errors_limit')
+        @errors_limit = Rails.application.secrets.supervisor_script_watcher['errors_limit']
       end
     end
   end
@@ -22,47 +26,60 @@ class SupervisorRunWatcher
   ##
   # Allows to start monitoring if needed
   def self.start_watching
-    @@mutex.synchronize do
-      unless @@is_running
+    @mutex.synchronize do
+      if @is_running
+        Rails.logger.debug 'Supervisor script watcher is already running'
+      else
         Rails.logger.debug 'Start supervisor script watcher'
         Thread.new do
           self.watching_loop
         end
-        @@is_running = true
-      else
-        Rails.logger.debug 'Supervisor script watcher is already running'
+        @is_running = true
       end
     end
   end
 
 
   def self.watching_loop
-    while true
-      @@mutex.synchronize do
+    errors_count = {}
+    loop do
+      @mutex.synchronize do
         begin
           Rails.logger.debug 'Supervisor script watch loop'
-          running_scripts = SupervisorRun.find_all_by_query(is_running: true)
-          if running_scripts.count == 0
+          runs = SupervisorRun.find_all_by_query(is_running: true, is_error: false)
+          if runs.count == 0
             Rails.logger.debug 'There are no more scripts to watch'
-            @@is_running = false
+            @is_running = false
             return
           end
-          running_scripts.each do |s|
+          runs.each do |run|
+            id = run.id.to_sym
             begin
-              s.monitoring_loop
-              s.save
-            rescue => s_error
-              Rails.logger.error "A fatal error occured for supervisor #{s.supervisor_id}: #{s_error.to_s}\n#{s_error.backtrace.join("\n")}"
-              s.destroy
+              run.monitoring_loop
+              run.save
+              errors_count[id] = 0
+            rescue => e
+              errors_count[id] = 0 unless errors_count.has_key? id
+              if errors_count[id] < @errors_limit
+                Rails.logger.error "Fatal error occurred during supervisor run monitoring execution [#{run.id}]:"\
+                                   "#{e.to_s}"
+                errors_count[id] += 1
+              else
+                Rails.logger.error "Fatal error occurred during supervisor run monitoring execution [#{run.id}], "\
+                                    "execution stopped : #{e.to_s}\n#{e.backtrace.join("\n")}"
+                run.set_error(e.to_s)
+                run.save
+              end
             end
           end
         rescue => e
-           Rails.logger.info "Error while execution script monitoring loop #{e.to_s}"
-           @@is_running = false
+           Rails.logger.error "Fatal error occurred during supervisor runs watcher thread: #{e.to_s}\n"\
+                              "#{e.backtrace.join("\n")}"
+           @is_running = false
            return
         end
       end
-      sleep(@@sleep_duration_in_seconds)
+      sleep(@sleep_duration_in_seconds)
     end
   end
 

--- a/app/models/supervisor_run_watcher.rb
+++ b/app/models/supervisor_run_watcher.rb
@@ -60,8 +60,7 @@ class SupervisorRunWatcher
             rescue => e
               errors_count[id] = 0 unless errors_count.has_key? id
               if errors_count[id] < @errors_limit
-                Rails.logger.error "Fatal error occurred during supervisor run monitoring execution [#{run.id}]:"\
-                                   "#{e.to_s}"
+                Rails.logger.warn "An error occurred during supervisor run monitoring execution [#{run.id}]:#{e.to_s}"
                 errors_count[id] += 1
               else
                 Rails.logger.error "Fatal error occurred during supervisor run monitoring execution [#{run.id}], "\

--- a/app/models/supervisor_run_watcher.rb
+++ b/app/models/supervisor_run_watcher.rb
@@ -55,8 +55,7 @@ class SupervisorRunWatcher
           runs.each do |run|
             id = run.id.to_sym
             begin
-              run.monitoring_loop
-              run.save
+              run.monitoring_loop!
               errors_count[id] = 0
             rescue => e
               errors_count[id] = 0 unless errors_count.has_key? id
@@ -67,8 +66,7 @@ class SupervisorRunWatcher
               else
                 Rails.logger.error "Fatal error occurred during supervisor run monitoring execution [#{run.id}], "\
                                     "execution stopped : #{e.to_s}\n#{e.backtrace.join("\n")}"
-                run.set_error(e.to_s)
-                run.save
+                run.set_error!(e.to_s)
               end
             end
           end

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -17,9 +17,11 @@ default: &DEFAULT
     ## NOTICE: this key should be set ONLY ONCE BEFORE first run - if you change or lost it, you will be UNABLE to read encrypted data!
     db_secret_key: "QjqjFK}7|Xw8DDMUP-O$yp"
 
-  ## Set an interval of script watching (checking if scripts are alive)
   supervisor_script_watcher:
+    ## Set an interval of script watching (checking if scripts are alive)
     sleep_duration_in_seconds: 60
+    ## Set retrying limit of monitoring loop after error
+    errors_limit = 3
 
   ## Path where logs are moved after supervisor run execution finish.
   # log_archive_path: /some/path

--- a/test/integration/generic_supervisor_run_starting_test.rb
+++ b/test/integration/generic_supervisor_run_starting_test.rb
@@ -36,8 +36,7 @@ class GenericSupervisorRunStartingTest < ActionDispatch::IntegrationTest
 
   test "id should be recognized as supervisor_id" do
     supervisor_run = mock do
-      expects(:start).with(ID, CONFIG['experiment_id'], @user_id, CONFIG).returns(1)
-      expects(:save)
+      expects(:start!).with(ID, CONFIG['experiment_id'], @user_id, CONFIG).returns(1)
       expects(:id).returns(ID)
     end
     SupervisorRun.expects(:new).returns(supervisor_run)

--- a/test/integration/generic_supervisor_run_starting_test.rb
+++ b/test/integration/generic_supervisor_run_starting_test.rb
@@ -40,7 +40,7 @@ class GenericSupervisorRunStartingTest < ActionDispatch::IntegrationTest
       expects(:save)
       expects(:id).returns(ID)
     end
-    SupervisorRun.expects(:new).with({}).returns(supervisor_run)
+    SupervisorRun.expects(:new).returns(supervisor_run)
 
     post create_run_supervisor_path(ID), config: CONFIG.to_json
 

--- a/test/models/supervisor_run_test.rb
+++ b/test/models/supervisor_run_test.rb
@@ -319,11 +319,13 @@ class SupervisorRunTest < ActiveSupport::TestCase
 
   test 'declare_persistent_method should create persistent method version' do
     # given
-    SupervisorRun.declare_persistent_method :test
-    @supervisor_run.expects(:test).with(:foo, :bar).returns(:bar)
-    @supervisor_run.expects(:save)
+    SupervisorRun.declare_persistent_method :method, :another_method
+    @supervisor_run.expects(:method).with(:foo, :bar).returns(:bar)
+    @supervisor_run.expects(:another_method)
+    @supervisor_run.expects(:save).twice
     # when, then
-    assert_equal :bar, @supervisor_run.test!(:foo, :bar)
+    assert_equal :bar, @supervisor_run.method!(:foo, :bar)
+    @supervisor_run.another_method!
   end
 
 end

--- a/test/models/supervisor_run_test.rb
+++ b/test/models/supervisor_run_test.rb
@@ -16,82 +16,82 @@ class SupervisorRunTest < ActiveSupport::TestCase
 
   def setup
     super
-    @supervisor_script = SupervisorRun.new
+    @supervisor_run = SupervisorRun.new
     @experiment = stub_everything 'experiment'
   end
 
   test 'check methods return true when script is running' do
-    @supervisor_script.pid = PID
-    @supervisor_script.is_running = true
+    @supervisor_run.pid = PID
+    @supervisor_run.is_running = true
 
-    @supervisor_script.expects(:`).with("ps #{PID}")
+    @supervisor_run.expects(:`).with("ps #{PID}")
     system('false')
     $?.expects(:success?).returns(true)
-    assert @supervisor_script.check, 'Check method should return true'
-    assert @supervisor_script.is_running, 'is_running flag should not be modified'
+    assert @supervisor_run.check, 'Check method should return true'
+    assert @supervisor_run.is_running, 'is_running flag should not be modified'
   end
 
   test 'check methods return false when script is not running and set is_running to false' do
-    @supervisor_script.pid = PID
-    @supervisor_script.is_running = true
+    @supervisor_run.pid = PID
+    @supervisor_run.is_running = true
 
-    @supervisor_script.expects(:`).with("ps #{PID}")
+    @supervisor_run.expects(:`).with("ps #{PID}")
     system('false')
     $?.expects(:success?).returns(false)
-    assert_not @supervisor_script.check, 'Check method should return false'
-    assert @supervisor_script.is_running, 'is_running flag should not be modified'
+    assert_not @supervisor_run.check, 'Check method should return false'
+    assert @supervisor_run.is_running, 'is_running flag should not be modified'
   end
 
   test 'monitoring loop proper behavior when script is running' do
-    @supervisor_script.is_running = true
+    @supervisor_run.is_running = true
     # mock
-    @supervisor_script.expects(:check).returns(true)
-    @supervisor_script.expects(:notify_error).never
+    @supervisor_run.expects(:check).returns(true)
+    @supervisor_run.expects(:notify_error).never
 
     # test
-    @supervisor_script.monitoring_loop
-    assert @supervisor_script.is_running, 'is_running flag should be true'
+    @supervisor_run.monitoring_loop
+    assert @supervisor_run.is_running, 'is_running flag should be true'
   end
 
   test 'monitoring loop proper behavior when script is not running and experiment is completed' do
-    @supervisor_script.is_running = true
+    @supervisor_run.is_running = true
     # mock
-    @supervisor_script.expects(:check).returns(false)
-    @supervisor_script.expects(:notify_error).with(MESSAGE)
-    @supervisor_script.expects(:read_log).returns('')
-    @supervisor_script.stubs(:experiment).returns(@experiment)
+    @supervisor_run.expects(:check).returns(false)
+    @supervisor_run.expects(:notify_error).with(MESSAGE)
+    @supervisor_run.expects(:read_log).returns('')
+    @supervisor_run.stubs(:experiment).returns(@experiment)
     @experiment.stubs(:completed).returns(false)
-    @supervisor_script.expects(:move_log)
+    @supervisor_run.expects(:move_log)
 
     # test
-    @supervisor_script.monitoring_loop
-    assert_not @supervisor_script.is_running, 'is_running flag should be false'
+    @supervisor_run.monitoring_loop
+    assert_not @supervisor_run.is_running, 'is_running flag should be false'
   end
 
   test 'do not notify error when script is not running and experiment is completed' do
-    @supervisor_script.is_running = true
+    @supervisor_run.is_running = true
     # mock
-    @supervisor_script.expects(:check).returns(false)
-    @supervisor_script.expects(:notify_error).never
-    @supervisor_script.stubs(:experiment).returns(@experiment)
+    @supervisor_run.expects(:check).returns(false)
+    @supervisor_run.expects(:notify_error).never
+    @supervisor_run.stubs(:experiment).returns(@experiment)
     @experiment.stubs(:completed).returns(true)
-    @supervisor_script.expects(:move_log)
+    @supervisor_run.expects(:move_log)
 
     # test
-    @supervisor_script.monitoring_loop
-    assert_not @supervisor_script.is_running, 'is_running flag should be false'
+    @supervisor_run.monitoring_loop
+    assert_not @supervisor_run.is_running, 'is_running flag should be false'
   end
 
   test 'monitoring loop should raise exception when script is not running' do
     e = assert_raises RuntimeError do
-      @supervisor_script.monitoring_loop
+      @supervisor_run.monitoring_loop
     end
     assert_equal e.to_s, 'Tried to check supervisor script executor state, but it is not running'
   end
 
   test 'proper behavior of notify error' do
-    @supervisor_script.experiment_id = EXPERIMENT_ID
-    @supervisor_script.experiment_manager_credentials = {'user' => USER, 'password' => PASSWORD}
+    @supervisor_run.experiment_id = EXPERIMENT_ID
+    @supervisor_run.experiment_manager_credentials = {'user' => USER, 'password' => PASSWORD}
     # mocks
     information_service = mock 'InformationService'
     information_service.expects(:sample_public_url).with('experiment_managers').returns(ADDRESS)
@@ -107,12 +107,12 @@ class SupervisorRunTest < ActiveSupport::TestCase
     ).returns({status: 'ok'}.to_json)
 
     # test
-    @supervisor_script.notify_error REASON
+    @supervisor_run.notify_error REASON
   end
 
   test 'proper behavior of notify error when there is no available experiment manager' do
-    @supervisor_script.experiment_id = EXPERIMENT_ID
-    @supervisor_script.experiment_manager_credentials = {'user' => USER, 'password' => PASSWORD}
+    @supervisor_run.experiment_id = EXPERIMENT_ID
+    @supervisor_run.experiment_manager_credentials = {'user' => USER, 'password' => PASSWORD}
     # mocks
     information_service = mock 'InformationService'
     information_service.expects(:sample_public_url).with('experiment_managers').returns(nil)
@@ -121,87 +121,87 @@ class SupervisorRunTest < ActiveSupport::TestCase
     RestClient::Request.expects(:execute).never
 
     # test
-    @supervisor_script.notify_error REASON
+    @supervisor_run.notify_error REASON
   end
 
   FILE_PATH = '/tmp/test.txt'
 
   test 'proper behavior od read_log method when lines number is greater than 100' do
-    @supervisor_script.expects(:log_path).returns(FILE_PATH)
+    @supervisor_run.expects(:log_path).returns(FILE_PATH)
 
     File.open(FILE_PATH, 'w+') do |file|
       (1..101).each {|x| file.write("#{x}\n")}
     end
-    assert_equal @supervisor_script.read_log, "#{(2..101).to_a.join("\n")}\n"
+    assert_equal @supervisor_run.read_log, "#{(2..101).to_a.join("\n")}\n"
     File.delete(FILE_PATH)
   end
 
   test 'proper behavior od read_log method when lines number is lower than 100' do
-    @supervisor_script.expects(:log_path).returns(FILE_PATH)
+    @supervisor_run.expects(:log_path).returns(FILE_PATH)
 
     File.open(FILE_PATH, 'w+') do |file|
       (1..99).each {|x| file.write("#{x}\n")}
     end
-    assert_equal @supervisor_script.read_log, "#{(1..99).to_a.join("\n")}\n"
+    assert_equal @supervisor_run.read_log, "#{(1..99).to_a.join("\n")}\n"
     File.delete(FILE_PATH)
   end
 
   test 'proper behavior od read_log method when lines number is equal 100' do
-    @supervisor_script.expects(:log_path).returns(FILE_PATH)
+    @supervisor_run.expects(:log_path).returns(FILE_PATH)
 
     File.open(FILE_PATH, 'w+') do |file|
       (1..100).each {|x| file.write("#{x}\n")}
     end
-    assert_equal @supervisor_script.read_log, "#{(1..100).to_a.join("\n")}\n"
+    assert_equal @supervisor_run.read_log, "#{(1..100).to_a.join("\n")}\n"
     File.delete(FILE_PATH)
   end
 
   test 'proper behavior od read_log method on file reading error' do
-    @supervisor_script.expects(:log_path).times(3).returns(FILE_PATH)
+    @supervisor_run.expects(:log_path).times(3).returns(FILE_PATH)
     IO.expects(:readlines).with(FILE_PATH).throws(StandardError)
-    assert_equal @supervisor_script.read_log, "Unable to load log file: #{FILE_PATH}"
+    assert_equal @supervisor_run.read_log, "Unable to load log file: #{FILE_PATH}"
   end
 
   test 'proper behaviour of stop method with stubborn process' do
-    @supervisor_script.pid = PID
-    @supervisor_script.is_running = true
-    @supervisor_script.expects(:check).returns(true).twice
+    @supervisor_run.pid = PID
+    @supervisor_run.is_running = true
+    @supervisor_run.expects(:check).returns(true).twice
     Process.expects(:kill).with('TERM', PID)
     Process.expects(:kill).with('KILL', PID)
 
-    @supervisor_script.stop
+    @supervisor_run.stop
 
-    assert_equal false, @supervisor_script.is_running
+    assert_equal false, @supervisor_run.is_running
   end
 
   test 'proper behaviour of stop method with cooperating process' do
-    @supervisor_script.pid = PID
-    @supervisor_script.is_running = true
-    @supervisor_script.expects(:check).returns(true).then.returns(false).twice
+    @supervisor_run.pid = PID
+    @supervisor_run.is_running = true
+    @supervisor_run.expects(:check).returns(true).then.returns(false).twice
     Process.expects(:kill).with('TERM', PID)
 
-    @supervisor_script.stop
+    @supervisor_run.stop
 
-    assert_equal false, @supervisor_script.is_running
+    assert_equal false, @supervisor_run.is_running
   end
 
 
   test 'proper behaviour of destroy method when script is not running' do
-    @supervisor_script.expects(:check).returns(false)
-    @supervisor_script.save
+    @supervisor_run.expects(:check).returns(false)
+    @supervisor_run.save
 
     assert_difference 'SupervisorRun.count', -1 do
-      @supervisor_script.destroy
+      @supervisor_run.destroy
     end
   end
 
   test 'proper behaviour of destroy method when script is running' do
-    @supervisor_script.expects(:check).returns(true)
-    @supervisor_script.expects(:stop)
-    @supervisor_script.save
+    @supervisor_run.expects(:check).returns(true)
+    @supervisor_run.expects(:stop)
+    @supervisor_run.save
 
     assert_difference 'SupervisorRun.count', -1 do
-      @supervisor_script.destroy
+      @supervisor_run.destroy
     end
   end
 
@@ -209,10 +209,10 @@ class SupervisorRunTest < ActiveSupport::TestCase
                         :is_error, :reason]
 
   test 'state returns all and only allowed keys' do
-    SupervisorRun::STATE_ALLOWED_KEYS.each {|key| @supervisor_script.send("#{key}=".to_sym, 'val')}
-    @supervisor_script.forbidden_key = 'val'
+    SupervisorRun::STATE_ALLOWED_KEYS.each {|key| @supervisor_run.send("#{key}=".to_sym, 'val')}
+    @supervisor_run.forbidden_key = 'val'
 
-    state = @supervisor_script.state
+    state = @supervisor_run.state
     assert_nothing_raised do
       state.assert_valid_keys(STATE_ALLOWED_KEYS)
     end
@@ -226,14 +226,14 @@ class SupervisorRunTest < ActiveSupport::TestCase
     original_log_file_path = AbstractSupervisorExecutor.log_path EXPERIMENT_ID
     new_log_file_path = ARCHIVE_LOG_PATH + AbstractSupervisorExecutor.log_file_name(EXPERIMENT_ID)
     FileUtils.touch(original_log_file_path)
-    @supervisor_script.stubs(:experiment_id).returns(EXPERIMENT_ID)
+    @supervisor_run.stubs(:experiment_id).returns(EXPERIMENT_ID)
     secrets = mock do
       stubs(:include?).with(:log_archive_path).returns(true)
       stubs(:log_archive_path).returns(ARCHIVE_LOG_PATH)
     end
     Rails.application.stubs(:secrets).returns(secrets)
     # when
-    @supervisor_script.send(:move_log) # hack to call private method
+    @supervisor_run.send(:move_log) # hack to call private method
     # then
     assert_not File.exists?(original_log_file_path), 'File should be moved to proper location'
     assert File.exists?(new_log_file_path), 'File should be moved to proper location'
@@ -247,13 +247,13 @@ class SupervisorRunTest < ActiveSupport::TestCase
     original_log_file_path = AbstractSupervisorExecutor.log_path EXPERIMENT_ID
     remove_file_if_exists original_log_file_path
     new_log_file_path = ARCHIVE_LOG_PATH + AbstractSupervisorExecutor.log_file_name(EXPERIMENT_ID)
-    @supervisor_script.stubs(:experiment_id).returns(EXPERIMENT_ID)
+    @supervisor_run.stubs(:experiment_id).returns(EXPERIMENT_ID)
     secrets = mock do
       stubs(:include?).with(:log_archive_path).returns(true)
     end
     Rails.application.stubs(:secrets).returns(secrets)
     # when
-    @supervisor_script.send(:move_log) # hack to call private method
+    @supervisor_run.send(:move_log) # hack to call private method
     # then
     assert_not File.exists?(new_log_file_path), 'Log file should not exist'
     # cleanup
@@ -265,13 +265,13 @@ class SupervisorRunTest < ActiveSupport::TestCase
     original_log_file_path = AbstractSupervisorExecutor.log_path EXPERIMENT_ID
     new_log_file_path = ARCHIVE_LOG_PATH + AbstractSupervisorExecutor.log_file_name(EXPERIMENT_ID)
     FileUtils.touch(original_log_file_path)
-    @supervisor_script.stubs(:experiment_id).returns(EXPERIMENT_ID)
+    @supervisor_run.stubs(:experiment_id).returns(EXPERIMENT_ID)
     secrets = mock do
       stubs(:include?).with(:log_archive_path).returns(false)
     end
     Rails.application.stubs(:secrets).returns(secrets)
     # when
-    @supervisor_script.send(:move_log) # hack to call private method
+    @supervisor_run.send(:move_log) # hack to call private method
     # then
     assert File.exists?(original_log_file_path), 'File should not be moved'
     assert_not File.exists?(new_log_file_path), 'File should not be moved'
@@ -287,14 +287,14 @@ class SupervisorRunTest < ActiveSupport::TestCase
     original_log_file_path = AbstractSupervisorExecutor.log_path EXPERIMENT_ID
     new_log_file_path = NOT_EXISTING_DIRECTORY + AbstractSupervisorExecutor.log_file_name(EXPERIMENT_ID)
     FileUtils.touch(original_log_file_path)
-    @supervisor_script.stubs(:experiment_id).returns(EXPERIMENT_ID)
+    @supervisor_run.stubs(:experiment_id).returns(EXPERIMENT_ID)
     secrets = mock do
       stubs(:include?).with(:log_archive_path).returns(true)
       stubs(:log_archive_path).returns(NOT_EXISTING_DIRECTORY)
     end
     Rails.application.stubs(:secrets).returns(secrets)
     # when
-    @supervisor_script.send(:move_log) # hack to call private method
+    @supervisor_run.send(:move_log) # hack to call private method
     # then
     assert File.exists?(original_log_file_path), 'File should not be moved'
     assert_not File.exists?(new_log_file_path), 'File should not be moved'
@@ -305,16 +305,25 @@ class SupervisorRunTest < ActiveSupport::TestCase
 
   test 'set_error should put run in error state and stop execution' do
     # given
-    @supervisor_script.is_error = false
-    @supervisor_script.stubs(:check).returns(true)
-    @supervisor_script.stubs(:read_log).returns('')
-    @supervisor_script.expects(:stop)
-    @supervisor_script.expects(:notify_error)
+    @supervisor_run.is_error = false
+    @supervisor_run.stubs(:check).returns(true)
+    @supervisor_run.stubs(:read_log).returns('')
+    @supervisor_run.expects(:stop)
+    @supervisor_run.expects(:notify_error)
     # when
-    @supervisor_script.set_error(REASON)
+    @supervisor_run.set_error(REASON)
     # then
-    assert_equal REASON, @supervisor_script.reason
-    assert_equal true, @supervisor_script.is_error
+    assert_equal REASON, @supervisor_run.reason
+    assert_equal true, @supervisor_run.is_error
+  end
+
+  test 'declare_persistent_method should create persistent method version' do
+    # given
+    SupervisorRun.declare_persistent_method :test
+    @supervisor_run.expects(:test).with(:foo, :bar).returns(:bar)
+    @supervisor_run.expects(:save)
+    # when, then
+    assert_equal :bar, @supervisor_run.test!(:foo, :bar)
   end
 
 end

--- a/test/models/supervisor_run_test.rb
+++ b/test/models/supervisor_run_test.rb
@@ -16,11 +16,11 @@ class SupervisorRunTest < ActiveSupport::TestCase
 
   def setup
     super
-    @supervisor_script = SupervisorRun.new({})
+    @supervisor_script = SupervisorRun.new
     @experiment = stub_everything 'experiment'
   end
 
-  test "check methods return true when script is running" do
+  test 'check methods return true when script is running' do
     @supervisor_script.pid = PID
     @supervisor_script.is_running = true
 
@@ -31,7 +31,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
     assert @supervisor_script.is_running, 'is_running flag should not be modified'
   end
 
-  test "check methods return false when script is not running and set is_running to false" do
+  test 'check methods return false when script is not running and set is_running to false' do
     @supervisor_script.pid = PID
     @supervisor_script.is_running = true
 
@@ -42,7 +42,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
     assert @supervisor_script.is_running, 'is_running flag should not be modified'
   end
 
-  test "monitoring loop proper behavior when script is running" do
+  test 'monitoring loop proper behavior when script is running' do
     @supervisor_script.is_running = true
     # mock
     @supervisor_script.expects(:check).returns(true)
@@ -53,7 +53,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
     assert @supervisor_script.is_running, 'is_running flag should be true'
   end
 
-  test "monitoring loop proper behavior when script is not running and experiment is completed" do
+  test 'monitoring loop proper behavior when script is not running and experiment is completed' do
     @supervisor_script.is_running = true
     # mock
     @supervisor_script.expects(:check).returns(false)
@@ -82,14 +82,14 @@ class SupervisorRunTest < ActiveSupport::TestCase
     assert_not @supervisor_script.is_running, 'is_running flag should be false'
   end
 
-  test "monitoring loop should raise exception when script is not running" do
+  test 'monitoring loop should raise exception when script is not running' do
     e = assert_raises RuntimeError do
       @supervisor_script.monitoring_loop
     end
-    assert_equal e.to_s, 'Tried to check supervisor script executior state, but it is not running'
+    assert_equal e.to_s, 'Tried to check supervisor script executor state, but it is not running'
   end
 
-  test "proper behavior of notify error" do
+  test 'proper behavior of notify error' do
     @supervisor_script.experiment_id = EXPERIMENT_ID
     @supervisor_script.experiment_manager_credentials = {'user' => USER, 'password' => PASSWORD}
     # mocks
@@ -110,7 +110,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
     @supervisor_script.notify_error REASON
   end
 
-  test "proper behavior of notify error when there is no available experiment manager" do
+  test 'proper behavior of notify error when there is no available experiment manager' do
     @supervisor_script.experiment_id = EXPERIMENT_ID
     @supervisor_script.experiment_manager_credentials = {'user' => USER, 'password' => PASSWORD}
     # mocks
@@ -126,7 +126,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
 
   FILE_PATH = '/tmp/test.txt'
 
-  test "proper behavior od read_log method when lines number is greater than 100" do
+  test 'proper behavior od read_log method when lines number is greater than 100' do
     @supervisor_script.expects(:log_path).returns(FILE_PATH)
 
     File.open(FILE_PATH, 'w+') do |file|
@@ -136,7 +136,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
     File.delete(FILE_PATH)
   end
 
-  test "proper behavior od read_log method when lines number is lower than 100" do
+  test 'proper behavior od read_log method when lines number is lower than 100' do
     @supervisor_script.expects(:log_path).returns(FILE_PATH)
 
     File.open(FILE_PATH, 'w+') do |file|
@@ -146,7 +146,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
     File.delete(FILE_PATH)
   end
 
-  test "proper behavior od read_log method when lines number is equal 100" do
+  test 'proper behavior od read_log method when lines number is equal 100' do
     @supervisor_script.expects(:log_path).returns(FILE_PATH)
 
     File.open(FILE_PATH, 'w+') do |file|
@@ -156,13 +156,13 @@ class SupervisorRunTest < ActiveSupport::TestCase
     File.delete(FILE_PATH)
   end
 
-  test "proper behavior od read_log method on file reading error" do
+  test 'proper behavior od read_log method on file reading error' do
     @supervisor_script.expects(:log_path).times(3).returns(FILE_PATH)
     IO.expects(:readlines).with(FILE_PATH).throws(StandardError)
     assert_equal @supervisor_script.read_log, "Unable to load log file: #{FILE_PATH}"
   end
 
-  test "proper behaviour of stop method with stubborn process" do
+  test 'proper behaviour of stop method with stubborn process' do
     @supervisor_script.pid = PID
     @supervisor_script.is_running = true
     @supervisor_script.expects(:check).returns(true).twice
@@ -174,7 +174,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
     assert_equal false, @supervisor_script.is_running
   end
 
-  test "proper behaviour of stop method with cooperating process" do
+  test 'proper behaviour of stop method with cooperating process' do
     @supervisor_script.pid = PID
     @supervisor_script.is_running = true
     @supervisor_script.expects(:check).returns(true).then.returns(false).twice
@@ -186,7 +186,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
   end
 
 
-  test "proper behaviour of destroy method when script is not running" do
+  test 'proper behaviour of destroy method when script is not running' do
     @supervisor_script.expects(:check).returns(false)
     @supervisor_script.save
 
@@ -195,7 +195,7 @@ class SupervisorRunTest < ActiveSupport::TestCase
     end
   end
 
-  test "proper behaviour of destroy method when script is running" do
+  test 'proper behaviour of destroy method when script is running' do
     @supervisor_script.expects(:check).returns(true)
     @supervisor_script.expects(:stop)
     @supervisor_script.save
@@ -205,13 +205,12 @@ class SupervisorRunTest < ActiveSupport::TestCase
     end
   end
 
-  STATE_ALLOWED_KEYS = [:experiment_id, :supervisor_id, :pid, :is_running, :supervisor_run_id]
+  STATE_ALLOWED_KEYS = [:experiment_id, :supervisor_id, :pid, :is_running, :supervisor_run_id, :user_id,
+                        :is_error, :reason]
 
-  test "state returns all and only allowed keys" do
-    @supervisor_script.experiment_id = 'val'
-    @supervisor_script.supervisor_id = 'val'
-    @supervisor_script.pid = 'val'
-    @supervisor_script.is_running = 'val'
+  test 'state returns all and only allowed keys' do
+    SupervisorRun::STATE_ALLOWED_KEYS.each {|key| @supervisor_script.send("#{key}=".to_sym, 'val')}
+    @supervisor_script.forbidden_key = 'val'
 
     state = @supervisor_script.state
     assert_nothing_raised do
@@ -302,8 +301,20 @@ class SupervisorRunTest < ActiveSupport::TestCase
     # cleanup
     remove_file_if_exists original_log_file_path
     remove_file_if_exists new_log_file_path
+  end
 
-
+  test 'set_error should put run in error state and stop execution' do
+    # given
+    @supervisor_script.is_error = false
+    @supervisor_script.stubs(:check).returns(true)
+    @supervisor_script.stubs(:read_log).returns('')
+    @supervisor_script.expects(:stop)
+    @supervisor_script.expects(:notify_error)
+    # when
+    @supervisor_script.set_error(REASON)
+    # then
+    assert_equal REASON, @supervisor_script.reason
+    assert_equal true, @supervisor_script.is_error
   end
 
 end

--- a/test/models/supervisor_run_watcher_test.rb
+++ b/test/models/supervisor_run_watcher_test.rb
@@ -63,8 +63,7 @@ class SupervisorRunWatcherTest < ActiveSupport::TestCase
     SupervisorRunWatcher.sleep_duration_in_seconds = 0
     SupervisorRunWatcher.is_running = true
     supervisor_script = mock do
-      expects(:monitoring_loop)
-      expects(:save)
+      expects(:monitoring_loop!)
       stubs(:id).returns('id')
     end
     SupervisorRun.expects(:find_all_by_query)
@@ -84,9 +83,8 @@ class SupervisorRunWatcherTest < ActiveSupport::TestCase
     supervisor_script = mock do
       stubs(:id).returns('id')
       stubs(:supervisor_id).returns('id')
-      stubs(:monitoring_loop).raises(StandardError)
-      expects(:set_error).then(is_error.is('true'))
-      expects(:save)
+      stubs(:monitoring_loop!).raises(StandardError)
+      expects(:set_error!).then(is_error.is('true'))
     end
     SupervisorRun.stubs(:find_all_by_query).returns([supervisor_script]).when(is_error.is('false'))
     SupervisorRun.stubs(:find_all_by_query).returns([]).when(is_error.is('true'))

--- a/test/models/supervisor_run_watcher_test.rb
+++ b/test/models/supervisor_run_watcher_test.rb
@@ -12,9 +12,9 @@ class SupervisorRunWatcherTest < ActiveSupport::TestCase
     attr_accessor :sleep_duration_in_seconds, :is_running, :errors_limit
   end
 
-  def self.create_config_entry_test(name, default_vale, new_value)
+  def self.create_config_entry_test(entry_name, default_value, config_value)
     instance_eval do
-      test "proper init of #{name} when config supervisor_script_watcher entry is missing" do
+      test "field #{entry_name} should be set to default when config for supervisor_script_watcher is missing" do
         # given
         secrets = mock do
           stubs(:include?).with(:supervisor_script_watcher).returns(false)
@@ -23,10 +23,10 @@ class SupervisorRunWatcherTest < ActiveSupport::TestCase
         # when
         SupervisorRunWatcher.init
         # then
-        assert_equal default_vale, SupervisorRunWatcher.send(name)
+        assert_equal default_value, SupervisorRunWatcher.send(entry_name)
       end
 
-      test "proper init when config entry #{name} is missing" do
+      test "field #{entry_name} should be set to default when its config entry is missing" do
         # given
         secrets = mock do
           stubs(:include?).with(:supervisor_script_watcher).returns(true)
@@ -37,28 +37,28 @@ class SupervisorRunWatcherTest < ActiveSupport::TestCase
         # when
         SupervisorRunWatcher.init
         # then
-        assert_equal default_vale, SupervisorRunWatcher.send(name)
+        assert_equal default_value, SupervisorRunWatcher.send(entry_name)
       end
 
-      test "proper init with existing config entry #{name}" do
+      test "field #{entry_name} should be set to config value" do
         # given
+        entry = {entry_name.to_s => config_value}
         secrets = mock do
           stubs(:include?).with(:supervisor_script_watcher).returns(true)
+          stubs(:supervisor_script_watcher).returns(entry)
         end
-        entry = {name.to_s => new_value}
-        secrets.stubs(:supervisor_script_watcher).returns(entry)
         Rails.application.stubs(:secrets).returns(secrets)
         # when
         SupervisorRunWatcher.init
         # then
-        assert_equal new_value, SupervisorRunWatcher.send(name)
+        assert_equal config_value, SupervisorRunWatcher.send(entry_name)
       end
     end
   end
   create_config_entry_test :sleep_duration_in_seconds, DEFAULT_VALUES[:sleep_duration_in_seconds], 30
   create_config_entry_test :errors_limit, DEFAULT_VALUES[:errors_limit], 5
 
-  test 'proper execution of supervisor script watcher' do
+  test 'supervisor run watcher should execute monitoring loop of active supervisors runs' do
     # given
     SupervisorRunWatcher.sleep_duration_in_seconds = 0
     SupervisorRunWatcher.is_running = true

--- a/test/models/supervisor_run_watcher_test.rb
+++ b/test/models/supervisor_run_watcher_test.rb
@@ -111,8 +111,6 @@ class SupervisorRunWatcherTest < ActiveSupport::TestCase
   end
 
   def teardown
-    SupervisorRunWatcher.is_running = DEFAULT_VALUES[:is_running]
-    SupervisorRunWatcher.sleep_duration_in_seconds = DEFAULT_VALUES[:sleep_duration_in_seconds]
-    SupervisorRunWatcher.errors_limit = DEFAULT_VALUES[:errors_limit]
+    DEFAULT_VALUES.each {|key, value| SupervisorRunWatcher.send("#{key}=".to_sym, value)}
   end
 end

--- a/test/models/supervisor_run_watcher_test.rb
+++ b/test/models/supervisor_run_watcher_test.rb
@@ -2,70 +2,119 @@ require 'test_helper'
 
 class SupervisorRunWatcherTest < ActiveSupport::TestCase
 
-  VALUE = 30
-  DEFAULT_VALUE = 60
+  DEFAULT_VALUES = {
+      sleep_duration_in_seconds: 60,
+      errors_limit: 5,
+      is_running: false
+  }
 
-  test "proper init when config supervisor_script_watcher entry is missing" do
-    secrets = mock()
-    secrets.expects(:include?).with(:supervisor_script_watcher).returns(false)
-    Rails.application.expects(:secrets).returns(secrets)
-    SupervisorRunWatcher.init
-    assert_equal SupervisorRunWatcher.class_eval {class_variable_get :@@sleep_duration_in_seconds}, DEFAULT_VALUE
+  class << SupervisorRunWatcher
+    attr_accessor :sleep_duration_in_seconds, :is_running, :errors_limit
   end
 
-  test "proper init when config sleep_duration_in_seconds entry is missing" do
-    secrets = mock()
-    secrets.expects(:include?).with(:supervisor_script_watcher).returns(true)
-    empty_entry = {}
-    secrets.expects(:supervisor_script_watcher).returns(empty_entry)
+  def self.create_config_entry_test(name, default_vale, new_value)
+    instance_eval do
+      test "proper init of #{name} when config supervisor_script_watcher entry is missing" do
+        # given
+        secrets = mock do
+          stubs(:include?).with(:supervisor_script_watcher).returns(false)
+        end
+        Rails.application.stubs(:secrets).returns(secrets)
+        # when
+        SupervisorRunWatcher.init
+        # then
+        assert_equal default_vale, SupervisorRunWatcher.send(name)
+      end
 
-    Rails.application.expects(:secrets).returns(secrets).twice
-    SupervisorRunWatcher.init
-    assert_equal SupervisorRunWatcher.class_eval {class_variable_get :@@sleep_duration_in_seconds}, DEFAULT_VALUE
+      test "proper init when config entry #{name} is missing" do
+        # given
+        secrets = mock do
+          stubs(:include?).with(:supervisor_script_watcher).returns(true)
+        end
+        empty_entry = {}
+        secrets.stubs(:supervisor_script_watcher).returns(empty_entry)
+        Rails.application.stubs(:secrets).returns(secrets)
+        # when
+        SupervisorRunWatcher.init
+        # then
+        assert_equal default_vale, SupervisorRunWatcher.send(name)
+      end
+
+      test "proper init with existing config entry #{name}" do
+        # given
+        secrets = mock do
+          stubs(:include?).with(:supervisor_script_watcher).returns(true)
+        end
+        entry = {name.to_s => new_value}
+        secrets.stubs(:supervisor_script_watcher).returns(entry)
+        Rails.application.stubs(:secrets).returns(secrets)
+        # when
+        SupervisorRunWatcher.init
+        # then
+        assert_equal new_value, SupervisorRunWatcher.send(name)
+      end
+    end
+  end
+  create_config_entry_test :sleep_duration_in_seconds, DEFAULT_VALUES[:sleep_duration_in_seconds], 30
+  create_config_entry_test :errors_limit, DEFAULT_VALUES[:errors_limit], 5
+
+  test 'proper execution of supervisor script watcher' do
+    # given
+    SupervisorRunWatcher.sleep_duration_in_seconds = 0
+    SupervisorRunWatcher.is_running = true
+    supervisor_script = mock do
+      expects(:monitoring_loop)
+      expects(:save)
+      stubs(:id).returns('id')
+    end
+    SupervisorRun.expects(:find_all_by_query)
+        .with(is_running: true, is_error: false).returns([supervisor_script])
+        .then.returns([])
+        .twice
+    # when
+    SupervisorRunWatcher.watching_loop
+    # then
+    assert_equal false, SupervisorRunWatcher.is_running
   end
 
-  test "proper init with config config value" do
-    secrets = mock()
-    secrets.expects(:include?).with(:supervisor_script_watcher).returns(true)
-    entry = {"sleep_duration_in_seconds" => VALUE}
-    secrets.expects(:supervisor_script_watcher).returns(entry).twice
-
-    Rails.application.expects(:secrets).returns(secrets).times 3
-    SupervisorRunWatcher.init
-    assert_equal SupervisorRunWatcher.class_eval {class_variable_get :@@sleep_duration_in_seconds}, VALUE
-  end
-
-  test "proper execution of supervisor script watcher" do
-    # mocks
-    SupervisorRunWatcher.class_eval {class_variable_set :@@sleep_duration_in_seconds, 1}
-
-    supervisor_script = mock()
-    supervisor_script.expects(:save)
-    supervisor_script.expects(:monitoring_loop)
-
-    SupervisorRun.expects(:find_all_by_query).with(is_running: true)
-        .returns([supervisor_script]).then.returns([]).twice
-
-    # test
+  test 'supervisor run watcher should set run into error state after several failures' do
+    # given
+    SupervisorRunWatcher.sleep_duration_in_seconds = 0
+    is_error = states('is_error').starts_as('false')
+    supervisor_script = mock do
+      stubs(:id).returns('id')
+      stubs(:supervisor_id).returns('id')
+      stubs(:monitoring_loop).raises(StandardError)
+      expects(:set_error).then(is_error.is('true'))
+      expects(:save)
+    end
+    SupervisorRun.stubs(:find_all_by_query).returns([supervisor_script]).when(is_error.is('false'))
+    SupervisorRun.stubs(:find_all_by_query).returns([]).when(is_error.is('true'))
+    # when, then
     SupervisorRunWatcher.watching_loop
   end
 
-  test "watch thread should be started only once" do
+  test 'watch thread should be started only once' do
+    # given
     Thread.expects(:new)
+    # when, then
     SupervisorRunWatcher.start_watching
     SupervisorRunWatcher.start_watching
   end
 
-  test "running watch thread again should be possible after ending previous thread" do
-    SupervisorRun.expects(:find_all_by_query).with(is_running: true).returns([])
+  test 'running watch thread again should be possible after ending previous thread' do
+    # given
+    SupervisorRun.stubs(:find_all_by_query).returns([])
     Thread.expects(:new).twice
+    # when, then
     SupervisorRunWatcher.start_watching
     SupervisorRunWatcher.watching_loop
     SupervisorRunWatcher.start_watching
   end
 
   def teardown
-    SupervisorRunWatcher.class_eval {class_variable_set :@@is_running, false}
-    SupervisorRunWatcher.class_eval {class_variable_set :@@sleep_duration_in_seconds, 60}
+    SupervisorRunWatcher.is_running = DEFAULT_VALUES[:is_running]
+    SupervisorRunWatcher.sleep_duration_in_seconds = DEFAULT_VALUES[:sleep_duration_in_seconds]
+    SupervisorRunWatcher.errors_limit = DEFAULT_VALUES[:errors_limit]
   end
 end


### PR DESCRIPTION
**Less error prone supervisor run watcher:**
Refactoring of supervisor run watcher :
- exception no longer stops monitoring thread
- checking only runs not in error state
- setting runs to error state after several tries
- set_error method in supervisor run
- refactoring of tests and related code

**Declaring persistent methods version in supervisor run**
Implementing declare_persistent_method to create persistent method
Declaring persistent method version for:
- start
- stop
- monitoring_loop
- set_error

**Tests refactoring.**
- script -> run
- double to single qouted
